### PR TITLE
Sync main into prod: stop baking HTTP_PROXY into Dockerfile image

### DIFF
--- a/.github/workflows/sync-proto.yml
+++ b/.github/workflows/sync-proto.yml
@@ -46,4 +46,13 @@ jobs:
 
           git add proto/directory/v1/directory.proto
           git commit -m "Sync directory.v1 from research-ambit-main@${{ github.sha }}"
-          git push origin main
+
+          for i in 1 2 3 4 5; do
+            git push origin main && exit 0
+            echo "Push rejected (attempt $i/5) — another sync likely raced us. Rebasing and retrying..."
+            sleep $((RANDOM % 5 + 1))
+            git fetch origin main
+            git rebase origin/main
+          done
+          echo "Failed to push after 5 attempts."
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 # Backend API - Node.js with PM2
 FROM node:20-alpine
 
-# Proxy for IITD network
+# Build-only proxy for npm. This service makes no runtime calls that need the
+# campus proxy (Cloudinary/nodemailer/etc. are public internet, and no code
+# reads HTTP_PROXY/HTTPS_PROXY) — do not bake HTTP_PROXY into the image, or it
+# leaks container-wide (e.g. into Coolify's wget-based health check, which
+# then tries routing its own loopback request through the proxy and fails).
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
-ENV HTTP_PROXY=$HTTP_PROXY
-ENV HTTPS_PROXY=$HTTPS_PROXY
 
 WORKDIR /app
 

--- a/protos/directory/v1/directory.proto
+++ b/protos/directory/v1/directory.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 
-// sync-test: touched to verify the proto-registry sync pipeline end-to-end.
 package directory.v1;
 
 // East-west contract for the research-ambit-main backend (Docker service

--- a/protos/directory/v1/directory.proto
+++ b/protos/directory/v1/directory.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+// sync-test: touched to verify the proto-registry sync pipeline end-to-end.
 package directory.v1;
 
 // East-west contract for the research-ambit-main backend (Docker service


### PR DESCRIPTION
## Summary
- Removes `ENV HTTP_PROXY=$HTTP_PROXY` / `ENV HTTPS_PROXY=$HTTPS_PROXY` from the Dockerfile, keeping the `ARG` for build-time npm access only.
- Verified via a fresh standalone clone (no sibling directories, simulating a Coolify GitHub App clone) that `docker build` succeeds and the built image no longer bakes the campus proxy into the container's runtime env — confirmed the app serves `/` with HTTP 200 and Docker's own `HEALTHCHECK` reports `healthy`.
- No application code (Cloudinary, nodemailer, no axios calls) reads `HTTP_PROXY`/`HTTPS_PROXY`, so removing them is safe and prevents the same class of bug that broke auth-service's Coolify health check (container-wide proxy env leaking into a wget/curl-based loopback health check).

## Test plan
- [x] Clean standalone clone in an isolated temp dir, `docker build` succeeds
- [x] `docker inspect` on built image confirms no `HTTP_PROXY`/`HTTPS_PROXY` baked into image `Config.Env`
- [x] `docker run` + curl to `/` returns HTTP 200
- [x] Docker `HEALTHCHECK` reports `healthy`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>