### PR TITLE
ci: make proto-registry consumer notification resilient to per-repo failures

### DIFF
--- a/.github/workflows/sync-proto.yml
+++ b/.github/workflows/sync-proto.yml
@@ -65,13 +65,36 @@ jobs:
       # Notify consumers listed for directory.v1 in proto-registry's
       # consumers.yml, so their own pull-proto.yml can fetch the update
       # instead of silently drifting (see consumers.yml for the full map).
+      # Each consumer is retried independently and a failure on one doesn't
+      # skip the rest — a bare loop with -e would abort on the first failed
+      # curl and silently leave later consumers un-notified (see the incident
+      # that motivated this: chatbot-agent's search.v1 stubs went stale for
+      # days after a dispatch failure in the sibling sync-search-proto.yml
+      # went unnoticed).
       - name: Notify consumers
         if: steps.commit.outputs.changed == 'true'
         run: |
+          FAILED=""
           for repo in api-gateway; do
-            curl -sf -X POST \
-              -H "Authorization: Bearer ${{ secrets.PROTO_REGISTRY_TOKEN }}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/IITD-Tech-Ambit/${repo}/dispatches" \
-              -d '{"event_type":"proto-updated","client_payload":{"package":"directory.v1"}}'
+            success=false
+            for attempt in 1 2 3; do
+              if curl -sf -X POST \
+                -H "Authorization: Bearer ${{ secrets.PROTO_REGISTRY_TOKEN }}" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/IITD-Tech-Ambit/${repo}/dispatches" \
+                -d '{"event_type":"proto-updated","client_payload":{"package":"directory.v1"}}'; then
+                success=true
+                break
+              fi
+              echo "Dispatch to ${repo} failed (attempt ${attempt}/3), retrying..."
+              sleep $((RANDOM % 5 + 1))
+            done
+            if [ "$success" = false ]; then
+              echo "::error::Failed to notify ${repo} after 3 attempts — it will not auto-regenerate stubs for this proto update and needs a manual sync."
+              FAILED="${FAILED} ${repo}"
+            fi
           done
+          if [ -n "$FAILED" ]; then
+            echo "::error::Consumers not notified:${FAILED}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Same fix as SEO-Backend-iitd's sync-search-proto.yml (see [that PR](https://github.com/IITD-Tech-Ambit/SEO-Backend-iitd/pull/new) for the incident that motivated it): the "Notify consumers" step ran under \`bash -e\` with no per-iteration error handling, so a failed dispatch curl would abort the loop and silently skip remaining consumers.
- \`directory.v1\` currently has one consumer (\`api-gateway\`), so this is low-risk today but closes the gap before a second consumer is added.

## Test plan
- [ ] CI passes on this PR