### PR TITLE
Sync search.v1 proto: add recommended_count field

### DIFF
--- a/protos/search/v1/search.proto
+++ b/protos/search/v1/search.proto
@@ -375,6 +375,9 @@ message TaxonomyFacultyResponse {
   int32 faculty_total = 2;
   TaxonomyPagination pagination = 3;
   Meta meta = 4;
+  // How many of kerberos_list to show by default before a "Show all" action
+  // is needed — a per-combination statistical cutoff, not a fixed page size.
+  int32 recommended_count = 5;
 }
 
 message TaxonomyFacultyPapersRequest {


### PR DESCRIPTION
## Summary
- Vendored `protos/search/v1/search.proto` had drifted behind `proto-registry` main
- Missing `int32 recommended_count = 5;` on `TaxonomyFacultyResponse` (added upstream by SEO-Backend-iitd, already synced into the registry)
- Pulls the canonical proto file in verbatim to restore grpc mesh consistency

## Test plan
- [ ] Confirm proto-sync check passes
- [ ] Regenerate any codegen stubs if this repo generates client code from the proto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recommended item count to taxonomy search results.
  * Results can now indicate how many items should appear by default before users select “Show all.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->