### PR TITLE
Sync search.v1 proto: add recommended_count field

### DIFF
--- a/protos/search/v1/search.proto
+++ b/protos/search/v1/search.proto
@@ -375,6 +375,9 @@ message TaxonomyFacultyResponse {
   int32 faculty_total = 2;
   TaxonomyPagination pagination = 3;
   Meta meta = 4;
+  // How many of kerberos_list to show by default before a "Show all" action
+  // is needed — a per-combination statistical cutoff, not a fixed page size.
+  int32 recommended_count = 5;
 }
 
 message TaxonomyFacultyPapersRequest {


### PR DESCRIPTION
## Summary
Promote the search.v1 proto sync (recommended_count field) from main to prod, keeping the grpc mesh consistent in production.

Merged to main in #63.