### PR TITLE
search proto: sync FacultyForQueryRequest fields

### DIFF
--- a/protos/search/v1/search.proto
+++ b/protos/search/v1/search.proto
@@ -185,6 +185,9 @@ message FacultyForQueryRequest {
   // "basic" | "advanced"; empty string means the service default ("advanced").
   string mode = 2;
   repeated string search_in = 3;
+  optional string refine_within = 4;
+  repeated string refine_chain = 5;
+  SearchFilters filters = 6;
 }
 message Faculty {
   string name = 1;


### PR DESCRIPTION
## Summary
- Proto-only sync, no functional change — keeps this repo's copy of search.proto in sync with proto-registry/SEO-Backend-iitd/api-gateway after adding refine_within/refine_chain/filters to FacultyForQueryRequest.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>