### PR TITLE
Faculty self-service: Background & Qualifications profile sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ owner-enforced: the gateway verifies the `ra_session` and injects a trusted
 |---|---|
 | `POST /api/directory/faculty/:kerberos/image` | Replace the profile photo (multipart, ≤5 MB, image only). Uploads to Cloudinary (`faculty_images`), sets `profile_image_url`. |
 | `PATCH /api/directory/faculty/:kerberos/visibility` | Show/hide the four metrics — `h_index`, `citations`, `papers`, `patents`. JSON body of booleans. |
+| `GET /api/directory/faculty/:kerberos/profile-extras` | Owner-only. Returns the **full** Background / Qualifications (incl. hidden content) for the edit view. |
+| `PATCH /api/directory/faculty/:kerberos/profile-extras` | Save Background / Qualifications + their visibility. Body: `{ background, qualifications[], background_visible, qualifications_visible }`. |
+
+**Background & Qualifications.** Two optional, **profile-only** sections
+(`background` string, `qualifications` string[]) with per-section visibility
+(`background_visible` / `qualifications_visible`, both default **`false`** →
+hidden). Unlike metrics, these are added **only in the profile response**
+(`getFacultyByKerberos`), *not* in `formatDirectoryFaculty`, so they never leak
+into search/listings. Content is **kept in the DB even when hidden** (so it can be
+shown again) and is **redacted to `null`** on the public profile read when hidden;
+the owner's edit view loads the full content through the authenticated
+`GET …/profile-extras` instead. Validation is enforced **only when a section is
+shown**: background ≥ 100 characters, ≥ 1 qualification. Writes flush the directory
+cache. Exposed to the frontend as `backgroundVisible` / `qualificationsVisible`
+(+ `background` / `qualifications`, `null` when hidden).
 
 **Metric visibility.** Each faculty doc carries `metric_visibility` (all default
 `true`). A hidden metric is **redacted to `null`** in the central

--- a/src/controllers/directoryController.js
+++ b/src/controllers/directoryController.js
@@ -2,7 +2,7 @@ import fs from "fs";
 import { asyncErrorHandler } from "../middleware/errorHandler.js";
 import { successResponse } from "../lib/responseUtils.js";
 import * as directoryService from "../services/directoryService.js";
-import { updateFacultyImageByKerberos, updateFacultyVisibilityByKerberos } from "../services/directoryRepository.js";
+import { updateFacultyImageByKerberos, updateFacultyVisibilityByKerberos, updateFacultyProfileExtrasByKerberos, resolveFacultyByKerberos } from "../services/directoryRepository.js";
 import { uploadToCloudinary } from "../lib/cloudinary.js";
 import { cacheDelByPrefix } from "../lib/cache.js";
 import { DIR_CACHE_PREFIX } from "../services/directoryCache.js";
@@ -166,6 +166,94 @@ directory.updateFacultyVisibility = asyncErrorHandler(async (req, res) => {
             patents: v.patents !== false,
         },
     }, "Visibility updated.", 200);
+});
+
+const BACKGROUND_MIN_CHARS = 100;
+
+// Faculty self-service: read one's OWN Background / Qualifications sections for
+// editing. Owner-only. Unlike the public profile read, this returns the full
+// content even when a section is hidden, so the owner can edit hidden text in
+// edit mode. The public /faculty/:kerberos/profile read redacts hidden content.
+directory.getFacultyProfileExtras = asyncErrorHandler(async (req, res) => {
+    const kerberos = String(req.params.kerberos || "").toLowerCase();
+    const authKerberos = String(req.headers["x-user-kerberos"] || "").toLowerCase();
+
+    if (!authKerberos) {
+        return res.status(401).json({ success: false, message: "Not authenticated." });
+    }
+    if (authKerberos !== kerberos) {
+        return res.status(403).json({ success: false, message: "You can only edit your own profile." });
+    }
+
+    const faculty = await resolveFacultyByKerberos(kerberos);
+    if (!faculty) {
+        return res.status(404).json({ success: false, message: `No faculty found for "${kerberos}".` });
+    }
+
+    return successResponse(res, {
+        background: faculty.background || "",
+        qualifications: Array.isArray(faculty.qualifications) ? faculty.qualifications : [],
+        backgroundVisible: faculty.background_visible === true,
+        qualificationsVisible: faculty.qualifications_visible === true,
+    }, "Profile extras fetched.", 200);
+});
+
+// Faculty self-service: save one's OWN Background / Qualifications sections and
+// their visibility. Owner-only. Content is stored even when a section is hidden
+// (kept in the DB so it can be shown again). Validation is enforced ONLY when a
+// section is being shown: background >= 100 chars, qualifications >= 1 item.
+// Flushes the directory cache so the change shows on the profile at once.
+directory.updateFacultyProfileExtras = asyncErrorHandler(async (req, res) => {
+    const kerberos = String(req.params.kerberos || "").toLowerCase();
+    const authKerberos = String(req.headers["x-user-kerberos"] || "").toLowerCase();
+
+    if (!authKerberos) {
+        return res.status(401).json({ success: false, message: "Not authenticated." });
+    }
+    if (authKerberos !== kerberos) {
+        return res.status(403).json({ success: false, message: "You can only edit your own profile." });
+    }
+
+    const body = req.body || {};
+    const background = typeof body.background === "string" ? body.background : "";
+    const qualifications = Array.isArray(body.qualifications)
+        ? body.qualifications.map((q) => String(q).trim()).filter(Boolean)
+        : [];
+    const backgroundVisible = body.background_visible === true;
+    const qualificationsVisible = body.qualifications_visible === true;
+
+    // Enforce minimums only when the section is shown; hidden content is stored as-is.
+    if (backgroundVisible && background.trim().length < BACKGROUND_MIN_CHARS) {
+        return res.status(400).json({
+            success: false,
+            message: `Background must be at least ${BACKGROUND_MIN_CHARS} characters to show it.`,
+        });
+    }
+    if (qualificationsVisible && qualifications.length === 0) {
+        return res.status(400).json({
+            success: false,
+            message: "Add at least one qualification to show this section.",
+        });
+    }
+
+    const updated = await updateFacultyProfileExtrasByKerberos(kerberos, {
+        background,
+        qualifications,
+        background_visible: backgroundVisible,
+        qualifications_visible: qualificationsVisible,
+    });
+    if (!updated) {
+        return res.status(404).json({ success: false, message: `No faculty found for "${kerberos}".` });
+    }
+
+    await cacheDelByPrefix(DIR_CACHE_PREFIX);
+
+    return successResponse(res, {
+        background: updated.background || "",
+        qualifications: Array.isArray(updated.qualifications) ? updated.qualifications : [],
+        backgroundVisible: updated.background_visible === true,
+        qualificationsVisible: updated.qualifications_visible === true,
+    }, "Profile updated.", 200);
 });
 
 export default directory;

--- a/src/models/faculty.js
+++ b/src/models/faculty.js
@@ -60,6 +60,26 @@ const facultySchema = new mongoose.Schema({
         papers:{ type:Boolean, default:true },
         patents:{ type:Boolean, default:true },
     },
+    // Optional profile-only sections the faculty can add and choose to show.
+    // Hidden by default; the content is kept in the DB even when hidden so it can
+    // be shown again. Only exposed on the /faculty/:kerberos/profile page —
+    // never in directory search/listings. Validation (>=100 chars background,
+    // >=1 qualification) is enforced on the write ONLY when the section is shown.
+    background:{
+        type:String,
+    },
+    qualifications:{
+        type:[String],
+        default:[],
+    },
+    background_visible:{
+        type:Boolean,
+        default:false,
+    },
+    qualifications_visible:{
+        type:Boolean,
+        default:false,
+    },
     designation:{
         type:String,
     },

--- a/src/routes/directory.js
+++ b/src/routes/directory.js
@@ -25,6 +25,10 @@ router.get("/faculty/:kerberos/publications", directory.getFacultyPublications);
 // the owner check in the controller).
 router.post("/faculty/:kerberos/image", uploadImage.single("image"), directory.updateFacultyImage);
 router.patch("/faculty/:kerberos/visibility", directory.updateFacultyVisibility);
+// Faculty self-edit of Background / Qualifications (owner-only; GET returns full
+// content incl. hidden for the edit view, PATCH saves + validates).
+router.get("/faculty/:kerberos/profile-extras", directory.getFacultyProfileExtras);
+router.patch("/faculty/:kerberos/profile-extras", directory.updateFacultyProfileExtras);
 router.get("/:id", directory.getFacultiesById);
 
 export default router;

--- a/src/services/directoryIdentityService.js
+++ b/src/services/directoryIdentityService.js
@@ -176,6 +176,19 @@ export const getFacultyByKerberos = async ({ kerberos } = {}) => {
         const subjectMap = await buildSubjectAreaMap(fkKids, fkE2k, fkS2k);
         const facultyResponse = formatDirectoryFaculty(faculty, subjectMap, { department });
 
+        // Profile-only sections (Background / Qualifications). Added here — NOT in
+        // the shared formatDirectoryFaculty — so they never leak into directory
+        // search/listings. Content is exposed only when the faculty has toggled the
+        // section on; the value stays in the DB regardless. The owner's edit view
+        // loads the full (incl. hidden) content via the authenticated profile-extras
+        // endpoint, not this public read.
+        const backgroundVisible = faculty.background_visible === true;
+        const qualificationsVisible = faculty.qualifications_visible === true;
+        facultyResponse.backgroundVisible = backgroundVisible;
+        facultyResponse.qualificationsVisible = qualificationsVisible;
+        facultyResponse.background = backgroundVisible ? (faculty.background || "") : null;
+        facultyResponse.qualifications = qualificationsVisible ? (faculty.qualifications || []) : null;
+
         return { message: "Faculty fetched successfully", data: facultyResponse };
     });
 };

--- a/src/services/directoryRepository.js
+++ b/src/services/directoryRepository.js
@@ -42,6 +42,26 @@ export function updateFacultyVisibilityByKerberos(kerberos, visibility) {
     ).lean();
 }
 
+/** Set a faculty member's profile-only Background / Qualifications sections and
+ * their visibility flags. `fields` is a subset of
+ * { background, qualifications, background_visible, qualifications_visible }.
+ * Content is written even when the corresponding section is hidden (kept in the
+ * DB so it can be shown again). Returns the updated doc, or null if none matched. */
+export function updateFacultyProfileExtrasByKerberos(kerberos, fields) {
+    const escaped = escapeRegex(kerberos);
+    const set = {};
+    if (typeof fields.background === "string") set.background = fields.background;
+    if (Array.isArray(fields.qualifications)) set.qualifications = fields.qualifications;
+    if (typeof fields.background_visible === "boolean") set.background_visible = fields.background_visible;
+    if (typeof fields.qualifications_visible === "boolean") set.qualifications_visible = fields.qualifications_visible;
+    if (Object.keys(set).length === 0) return Promise.resolve(null);
+    return Faculty.findOneAndUpdate(
+        { email: new RegExp("^" + escaped + "@", "i") },
+        { $set: set },
+        { new: true },
+    ).lean();
+}
+
 export function findFacultyById(id) {
     return Faculty.findById(id).lean();
 }


### PR DESCRIPTION
Two optional, profile-only sections faculty can add to their own directory profile, each with its own visibility toggle (both hidden by default):

- background (string) + qualifications (string[]) on the faculty model, with background_visible / qualifications_visible flags.
- Exposed only in the profile response (directoryIdentityService.getFacultyByKerberos), NOT in the shared formatDirectoryFaculty, so they never leak into search/listings. Content is redacted to null on the public read when hidden.
- Owner-only GET/PATCH /faculty/:kerberos/profile-extras: GET returns the full content (incl. hidden) for the edit view; PATCH saves + validates. Content is kept in the DB even when hidden so it can be shown again. Validation enforced only when a section is shown: background >= 100 chars, >= 1 qualification.
- Writes flush the directory cache.

Verified end-to-end through the gateway on a writable local DB (owner-auth 401/403, validation 400s, profile-only exposure, hide-keeps-content-in-DB, redaction); prod DB never written (backend on read-only prod throughout).